### PR TITLE
Create Low-Heated compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     // modCompileOnly "maven.modrinth:create-alloyed:${alloyed_version}"
     modCompileOnly "maven.modrinth:create-cyber-goggles:${goggles_version}"
     modRuntimeOnly "maven.modrinth:create-cyber-goggles:${goggles_version}"
+    modImplementation "maven.modrinth:create-low-heated:${create_low_heated_version}"
 
     modCompileOnly "curse.maven:more-create-burners-1111030:${burners_version}"
     modRuntimeOnly "curse.maven:more-create-burners-1111030:${burners_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,8 @@ goggles_version=1.20.1-6.7.8-Forge
 burners_version=7395216
 # https://modrinth.com/mod/create-new-age
 new_age_version=zQStvTFw
+# https://modrinth.com/mod/create-low-heated
+create_low_heated_version=1.20.1-6.0.8-4
 # TiC Extensions
 tinkers_calibration_version=6809035
 # Others

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=false
 mod_version=0.5.2
 artifact_minecraft_version=1.20.1
 minecraft_version=1.20.1
-forge_version=47.1.33
+forge_version=47.4.0
 # Build Dependency Versions
 mixin_version=0.8.5
 parchment_version=2023.09.03

--- a/src/generated/resources/data/tconstruct/tags/blocks/fuel_tanks.json
+++ b/src/generated/resources/data/tconstruct/tags/blocks/fuel_tanks.json
@@ -8,6 +8,10 @@
     {
       "id": "moreburners:electric_burner",
       "required": false
+    },
+    {
+      "id": "createlowheated:basic_burner",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/tconstruct/tags/blocks/fuel_tanks.json
+++ b/src/generated/resources/data/tconstruct/tags/blocks/fuel_tanks.json
@@ -8,10 +8,6 @@
     {
       "id": "moreburners:electric_burner",
       "required": false
-    },
-    {
-      "id": "createlowheated:basic_burner",
-      "required": false
     }
   ]
 }

--- a/src/main/java/ho/artisan/tgears/compat/TinkersGearsCompat.java
+++ b/src/main/java/ho/artisan/tgears/compat/TinkersGearsCompat.java
@@ -9,12 +9,14 @@ public final class TinkersGearsCompat {
     public static final String CEI = "create_enchantment_industry";
     public static final String TI = "tinkersinnovation";
     public static final String CCG = "create_cyber_goggles";
+    public static final String CLH = "createlowheated";
 
     public static final boolean METALLURGY_LOADED = ModList.get().isLoaded(CM);
     public static final boolean ALLOYED_LOADED = ModList.get().isLoaded(AL);
     public static final boolean ADDITION_LOADED = ModList.get().isLoaded(CA);
     public static final boolean ENCHANTMENT_LOADED = ModList.get().isLoaded(CEI);
     public static final boolean GOGGLES_LOADED = ModList.get().isLoaded(CCG);
+    public static final boolean LOW_HEATED_LOADED = ModList.get().isLoaded(CLH);
 
     public static void load() {
     }

--- a/src/main/java/ho/artisan/tgears/data/provider/tag/TGBlockTagGen.java
+++ b/src/main/java/ho/artisan/tgears/data/provider/tag/TGBlockTagGen.java
@@ -45,7 +45,8 @@ public final class TGBlockTagGen extends TGTagGen<Block> {
         prov.tag(TinkerTags.Blocks.FUEL_TANKS)
                 .add(AllBlocks.BLAZE_BURNER.get())
                 .addOptional(CABlocks.LIQUID_BLAZE_BURNER.getId())
-                .addOptional(BlockRegistry.ELECTRIC_BURNER.getId());
+                .addOptional(BlockRegistry.ELECTRIC_BURNER.getId())
+                .addOptional(zeh.createlowheated.AllBlocks.BASIC_BURNER.getId());
 
         prov.tag(TGTagKeys.Blocks.SPOUT_ATTACHMENTS)
                 .add(Blocks.LEVER)

--- a/src/main/java/ho/artisan/tgears/data/provider/tag/TGBlockTagGen.java
+++ b/src/main/java/ho/artisan/tgears/data/provider/tag/TGBlockTagGen.java
@@ -45,8 +45,7 @@ public final class TGBlockTagGen extends TGTagGen<Block> {
         prov.tag(TinkerTags.Blocks.FUEL_TANKS)
                 .add(AllBlocks.BLAZE_BURNER.get())
                 .addOptional(CABlocks.LIQUID_BLAZE_BURNER.getId())
-                .addOptional(BlockRegistry.ELECTRIC_BURNER.getId())
-                .addOptional(zeh.createlowheated.AllBlocks.BASIC_BURNER.getId());
+                .addOptional(BlockRegistry.ELECTRIC_BURNER.getId());
 
         prov.tag(TGTagKeys.Blocks.SPOUT_ATTACHMENTS)
                 .add(Blocks.LEVER)

--- a/src/main/java/ho/artisan/tgears/mixin/burner/BasicBurnerActive.java
+++ b/src/main/java/ho/artisan/tgears/mixin/burner/BasicBurnerActive.java
@@ -1,0 +1,24 @@
+package ho.artisan.tgears.mixin.burner;
+
+import com.tterrag.registrate.util.entry.BlockEntry;
+import ho.artisan.tgears.index.TGTagKeys;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import zeh.createlowheated.content.processing.basicburner.BasicBurnerBlockEntity;
+
+@Mixin(BasicBurnerBlockEntity.class)
+public class BasicBurnerActive {
+    @Redirect(
+            remap = false,
+            method = "isValidBlockAbove",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/tterrag/registrate/util/entry/BlockEntry;has(Lnet/minecraft/world/level/block/state/BlockState;)Z"
+            )
+    )
+    public boolean valid(BlockEntry<?> instance, BlockState state) {
+        return instance.has(state) || state.is(TGTagKeys.Blocks.BURNER_TARGETS);
+    }
+}

--- a/src/main/java/ho/artisan/tgears/mixin/burner/BasicBurnerHeatSource.java
+++ b/src/main/java/ho/artisan/tgears/mixin/burner/BasicBurnerHeatSource.java
@@ -1,0 +1,31 @@
+package ho.artisan.tgears.mixin.burner;
+
+import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
+import ho.artisan.tgears.api.ITinkerBlockHeatSource;
+import ho.artisan.tgears.util.BlazeBurnerUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import zeh.createlowheated.content.processing.basicburner.BasicBurnerBlock;
+
+@Mixin(BasicBurnerBlock.class)
+public class BasicBurnerHeatSource implements ITinkerBlockHeatSource {
+    @Override
+    public int getTemperature(Level level, BlockPos pos) {
+        BlockState burner = level.getBlockState(pos);
+        return BlazeBurnerUtil.getTemperature(burner.getValue(BasicBurnerBlock.HEAT_LEVEL));
+    }
+
+    @Override
+    public int getRate(Level level, BlockPos pos) {
+        BlockState burner = level.getBlockState(pos);
+        return BlazeBurnerUtil.getRate(burner.getValue(BasicBurnerBlock.HEAT_LEVEL));
+    }
+
+    @Override
+    public boolean isHeating(Level level, BlockPos pos) {
+        //Always return true to prevent the Melter from eating fuel
+        return true;
+    }
+}

--- a/src/main/java/ho/artisan/tgears/mixin/burner/BasicBurnerItemHandler.java
+++ b/src/main/java/ho/artisan/tgears/mixin/burner/BasicBurnerItemHandler.java
@@ -1,0 +1,51 @@
+package ho.artisan.tgears.mixin.burner;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import zeh.createlowheated.content.processing.basicburner.BasicBurnerBlockEntity;
+
+@Mixin(value = BasicBurnerBlockEntity.BurnerItemHandler.class, remap = false)
+public class BasicBurnerItemHandler implements IItemHandlerModifiable {
+    @Shadow
+    @Final
+    BasicBurnerBlockEntity this$0;
+
+    @Override
+    public void setStackInSlot(int i, @NotNull ItemStack itemStack) {
+        this.this$0.inputInv.setStackInSlot(0, itemStack);
+    }
+
+    @Shadow
+    public int getSlots() {
+        throw new AssertionError();
+    }
+
+    @Shadow
+    public @NotNull ItemStack getStackInSlot(int slot) {
+        throw new AssertionError();
+    }
+
+    @Shadow
+    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        throw new AssertionError();
+    }
+
+    @Shadow
+    public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
+        throw new AssertionError();
+    }
+
+    @Shadow
+    public int getSlotLimit(int slot) {
+        throw new AssertionError();
+    }
+
+    @Shadow
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+        throw new AssertionError();
+    }
+}

--- a/src/main/java/ho/artisan/tgears/util/BlazeBurnerUtil.java
+++ b/src/main/java/ho/artisan/tgears/util/BlazeBurnerUtil.java
@@ -1,11 +1,14 @@
 package ho.artisan.tgears.util;
 
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
+import ho.artisan.tgears.TinkersGears;
 import ho.artisan.tgears.TinkersGearsConfig;
 import net.minecraft.network.chat.Component;
 import slimeknights.tconstruct.smeltery.block.entity.module.SolidFuelModule;
 
 import java.util.List;
+
+import static ho.artisan.tgears.compat.TinkersGearsCompat.LOW_HEATED_LOADED;
 
 public final class BlazeBurnerUtil {
 
@@ -13,21 +16,43 @@ public final class BlazeBurnerUtil {
     }
 
     public static int getTemperature(BlazeBurnerBlock.HeatLevel level) {
-        return switch (level) {
-            case NONE -> 0;
-            case SMOULDERING -> TinkersGearsConfig.server().extinguishedTemperature.get();
-            case FADING, KINDLED -> TinkersGearsConfig.server().kindledTemperature.get();
-            case SEETHING -> TinkersGearsConfig.server().seethingTemperature.get();
-        };
+        if (LOW_HEATED_LOADED){
+            return switch (level.ordinal()){ //Create Low-Heated
+                case 0, 1 -> 0; //None, Smouldering
+                case 5 -> TinkersGearsConfig.server().extinguishedTemperature.get(); //Low
+                case 2, 3 -> TinkersGearsConfig.server().kindledTemperature.get(); //Fading, Kindled
+                case 4 -> TinkersGearsConfig.server().seethingTemperature.get(); // Seething
+                default -> throw new IllegalStateException("Unexpected Temperature ordinal: " + level.ordinal());
+            };
+        }
+        else{
+            return switch (level) {
+                case NONE -> 0;
+                case SMOULDERING -> TinkersGearsConfig.server().extinguishedTemperature.get();
+                case FADING, KINDLED -> TinkersGearsConfig.server().kindledTemperature.get();
+                case SEETHING -> TinkersGearsConfig.server().seethingTemperature.get();
+            };
+        }
     }
 
     public static int getRate(BlazeBurnerBlock.HeatLevel level) {
-        return switch (level) {
-            case NONE -> 0;
-            case SMOULDERING -> TinkersGearsConfig.server().extinguishedRate.get();
-            case FADING, KINDLED -> TinkersGearsConfig.server().kindledRate.get();
-            case SEETHING -> TinkersGearsConfig.server().seethingRate.get();
-        };
+        if (LOW_HEATED_LOADED){
+            return switch (level.ordinal()){ //Create Low-Heated
+                case 0, 1 -> 0; //None, Smouldering
+                case 5 -> TinkersGearsConfig.server().extinguishedRate.get(); //Low
+                case 2, 3 -> TinkersGearsConfig.server().kindledRate.get(); //Fading, Kindled
+                case 4 -> TinkersGearsConfig.server().seethingRate.get(); // Seething
+                default -> throw new IllegalStateException("Unexpected Rate ordinal: " + level.ordinal());
+            };
+        }
+        else {
+            return switch (level) {
+                case NONE -> 0;
+                case SMOULDERING -> TinkersGearsConfig.server().extinguishedRate.get();
+                case FADING, KINDLED -> TinkersGearsConfig.server().kindledRate.get();
+                case SEETHING -> TinkersGearsConfig.server().seethingRate.get();
+            };
+        }
     }
 
     public static void addToGoggleTooltip(List<Component> tooltip, SolidFuelModule module) {

--- a/src/main/resources/tgears.mixins.json
+++ b/src/main/resources/tgears.mixins.json
@@ -1,39 +1,42 @@
 {
-	"required": true,
-	"priority": 1100,
-	"package": "ho.artisan.tgears.mixin",
-	"compatibilityLevel": "JAVA_17",
-	"refmap": "tgears.refmap.json",
-	"mixins": [
-		"assessor.AccessorCrushingWrapper",
-		"assessor.AccessorSpoutTank",
-		"burner.AlloyerFuelExtension",
-		"burner.BaseBurnerHeatSource",
-		"burner.BlazeBurnerActive",
-		"burner.BlazeBurnerHeatSource",
-		"burner.LiquidBlazeBurnerActive",
-		"burner.LiquidBlazeBurnerHeatSource",
-		"burner.MelterFuelExtension",
-		"crushing.BeltInventoryCheckFix",
-		"crushing.CoveringBeltFix",
-		"crushing.CrushingBlockEntityTick",
-		"fan.AirCurrentExpansion",
-		"fan.CastingContainerProcessing",
-		"interact.CastingBlockInteractFix",
-		"modifier.DivingBootsModification",
-		"modifier.TinkerCardboardArmorSupport",
-		"modifier.TinkerWrenchSupport",
-		"spout.SpoutBlockEntityTick",
-		"tooltip.AlloyerInfo",
-		"tooltip.CastingContainerInfo",
-		"tooltip.MelterInfo",
-		"tooltip.TankInfo"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	},
-	"minVersion": "0.8",
-	"client": [
-		"modifier.TinkerCardboardArmorOverlay"
+  "required": true,
+  "priority": 1100,
+  "package": "ho.artisan.tgears.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "refmap": "tgears.refmap.json",
+  "mixins": [
+    "assessor.AccessorCrushingWrapper",
+    "assessor.AccessorSpoutTank",
+    "burner.AlloyerFuelExtension",
+    "burner.BaseBurnerHeatSource",
+    "burner.BasicBurnerActive",
+    "burner.BasicBurnerHeatSource",
+    "burner.BasicBurnerItemHandler",
+    "burner.BlazeBurnerActive",
+    "burner.BlazeBurnerHeatSource",
+    "burner.LiquidBlazeBurnerActive",
+    "burner.LiquidBlazeBurnerHeatSource",
+    "burner.MelterFuelExtension",
+    "crushing.BeltInventoryCheckFix",
+    "crushing.CoveringBeltFix",
+    "crushing.CrushingBlockEntityTick",
+    "fan.AirCurrentExpansion",
+    "fan.CastingContainerProcessing",
+    "interact.CastingBlockInteractFix",
+    "modifier.DivingBootsModification",
+    "modifier.TinkerCardboardArmorSupport",
+    "modifier.TinkerWrenchSupport",
+    "spout.SpoutBlockEntityTick",
+    "tooltip.AlloyerInfo",
+    "tooltip.CastingContainerInfo",
+    "tooltip.MelterInfo",
+    "tooltip.TankInfo"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "minVersion": "0.8",
+  "client": [
+    "modifier.TinkerCardboardArmorOverlay"
 	]
 }


### PR DESCRIPTION
Disables Smouldering temperature/fuel rate when Create Low-Heated is installed.

EDIT: Added support for Basic Burners as heat sources. Provides Extinguished temperature/rate when lit, and Kindled when boosted with a Fan. Fuel can also be inserted using the Melter GUI.